### PR TITLE
Take 1 at fixing tests

### DIFF
--- a/tests/unit/suites/libraries/cms/editor/JEditorTest.php
+++ b/tests/unit/suites/libraries/cms/editor/JEditorTest.php
@@ -6,6 +6,8 @@
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license	    GNU General Public License version 2 or later; see LICENSE
  */
+ 
+ use Joomla\CMS\Editor\Editor as JEditor;
 
 /**
  * Test class for JEditor.
@@ -34,7 +36,7 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 	 */
 	protected function setUp()
 	{
-		$this->object = new Editor;
+		$this->object = new JEditor;
 	}
 
 	/**
@@ -47,8 +49,8 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 	public function testGetInstance()
 	{
 		$this->assertThat(
-			Editor::getInstance('none'),
-			$this->isInstanceOf('Editor')
+			JEditor::getInstance('none'),
+			$this->isInstanceOf('\Joomla\CMS\Editor\Editor')
 		);
 	}
 
@@ -66,7 +68,7 @@ class JEditorTest extends PHPUnit_Framework_TestCase
 
 		$this->assertThat(
 			$this->object->getState(),
-			$this->equalTo('Editor::getState()')
+			$this->equalTo('JEditor::getState()')
 		);
 	}
 }


### PR DESCRIPTION
So unit tests are in the global namespace. This means that you need to do the same thing there that you are doing in the other classes. Use the namespace as an alias to the old class name. Just did this quickly so haven't run the tests - but see how this goes